### PR TITLE
Change convention to use version catalog accessor

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -2,5 +2,6 @@
 <project version="4">
   <component name="VcsDirectoryMappings">
     <mapping directory="" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
   </component>
 </project>

--- a/config/detekt/baseline.yml
+++ b/config/detekt/baseline.yml
@@ -4,6 +4,9 @@
   <CurrentIssues>
     <ID>ComplexCondition:Dangerfile.df.kts$!isFeatureBranch &amp;&amp; !isReleaseBranch &amp;&amp; !isDependabotBranch &amp;&amp; !isRenovateBranch</ID>
     <ID>LongMethod:PublishingConfigTest.kt$PublishingConfigTest$@Test fun `GIVEN project WHEN configurePublishing() THEN publishing pom configured`()</ID>
+    <ID>MaxLineLength:PublishingConfig.kt$PublishingConfig$"https://github.com/${extension.publishGitHubOrganization.get()}/${extension.publishGitHubRepositoryName.get()}/"</ID>
+    <ID>MaxLineLength:PublishingConfig.kt$PublishingConfig$"scm:git:git://github.com/${extension.publishGitHubOrganization.get()}/${extension.publishGitHubRepositoryName.get()}.git"</ID>
+    <ID>MaxLineLength:PublishingConfig.kt$PublishingConfig$"scm:git:ssh://github.com/${extension.publishGitHubOrganization.get()}/${extension.publishGitHubRepositoryName.get()}.git"</ID>
     <ID>SwallowedException:TestVersionCatalogAccessor.kt$TestVersionCatalogAccessor$error: Throwable</ID>
     <ID>TooManyFunctions:GradlePluginConventionPlugin.kt$GradlePluginConventionPlugin : PluginPlugin</ID>
   </CurrentIssues>

--- a/plugin-development/gradle-plugin-convention/api/gradle-plugin-convention.api
+++ b/plugin-development/gradle-plugin-convention/api/gradle-plugin-convention.api
@@ -42,11 +42,6 @@ public abstract interface class eu/bitfunk/gradle/plugin/development/convention/
 
 public final class eu/bitfunk/gradle/plugin/development/convention/GradlePluginConventionPlugin : eu/bitfunk/gradle/plugin/development/convention/GradlePluginConventionContract$Plugin, org/gradle/api/Plugin {
 	public static final field COVERAGE_MINIMUM D
-	public static final field GRADLE_TEST_UTIL Ljava/lang/String;
-	public static final field GRADLE_VERSION Ljava/lang/String;
-	public static final field JACOCO_VERSION Ljava/lang/String;
-	public static final field JUNIT_5_VERSION Ljava/lang/String;
-	public static final field MOCKK_VERSION Ljava/lang/String;
 	public fun <init> ()V
 	public fun addExtension (Lorg/gradle/api/Project;)Leu/bitfunk/gradle/plugin/development/convention/GradlePluginConventionContract$Extension;
 	public fun addPlugins (Lorg/gradle/api/Project;)V

--- a/plugin-development/gradle-plugin-convention/build.gradle.kts
+++ b/plugin-development/gradle-plugin-convention/build.gradle.kts
@@ -79,42 +79,45 @@ dependencies {
     testImplementation(libsPluginConvention.testGradleTestUtil)
 }
 
-mavenPublishing {
-    group = requireNotNull(project.group)
-    version = requireNotNull(project.version)
+afterEvaluate {
+    mavenPublishing {
+        group = requireNotNull(project.group)
+        version = requireNotNull(project.version)
 
-    publishToMavenCentral(SonatypeHost.S01)
-    signAllPublications()
-    configure(
-        GradlePlugin(
-            javadocJar = JavadocJar.Javadoc(),
-            sourcesJar = true
-        )
-    )
-    pom {
-        name.set("Gradle plugin development convention")
-        description.set("A Collection of Gradle plugins to simplify and unify project development.")
-        inceptionYear.set("${Year.now().value}")
-        url.set("https://github.com/bitfunk/gradle-plugins/")
-        licenses {
-            license {
-                name.set("ISC License")
-                url.set("https://opensource.org/licenses/isc")
-                distribution.set("https://github.com/bitfunk/gradle-plugins/blob/main/LICENSE")
-            }
-        }
-        developers {
-            developer {
-                id.set("bitfunk")
-                name.set("Wolf-Martell Montwé (bitfunk)")
-                url.set("https://github.com/bitfunk/")
-            }
-        }
-        scm {
+        pom {
+            name.set("Gradle plugin development convention")
+            description.set("A Collection of Gradle plugins to simplify and unify project development.")
+            inceptionYear.set("${Year.now().value}")
             url.set("https://github.com/bitfunk/gradle-plugins/")
-            connection.set("scm:git:git://github.com/bitfunk/gradle-plugins.git")
-            developerConnection.set("scm:git:ssh://github.com/bitfunk/gradle-plugins.git")
+            licenses {
+                license {
+                    name.set("ISC License")
+                    url.set("https://opensource.org/licenses/isc")
+                    distribution.set("https://github.com/bitfunk/gradle-plugins/blob/main/LICENSE")
+                }
+            }
+            developers {
+                developer {
+                    id.set("bitfunk")
+                    name.set("Wolf-Martell Montwé (bitfunk)")
+                    url.set("https://github.com/bitfunk/")
+                }
+            }
+            scm {
+                url.set("https://github.com/bitfunk/gradle-plugins/")
+                connection.set("scm:git:git://github.com/bitfunk/gradle-plugins.git")
+                developerConnection.set("scm:git:ssh://github.com/bitfunk/gradle-plugins.git")
+            }
         }
+
+        publishToMavenCentral(SonatypeHost.S01)
+        signAllPublications()
+        configure(
+            GradlePlugin(
+                javadocJar = JavadocJar.Javadoc(),
+                sourcesJar = true
+            )
+        )
     }
 }
 

--- a/plugin-development/gradle-plugin-convention/build.gradle.kts
+++ b/plugin-development/gradle-plugin-convention/build.gradle.kts
@@ -32,7 +32,7 @@ plugins {
 }
 
 group = "eu.bitfunk.gradle.plugin.development.convention"
-version = "0.0.3-SNAPSHOT"
+version = "0.0.4"
 
 repositories {
     gradlePluginPortal()

--- a/plugin-development/gradle-plugin-convention/build.gradle.kts
+++ b/plugin-development/gradle-plugin-convention/build.gradle.kts
@@ -32,7 +32,7 @@ plugins {
 }
 
 group = "eu.bitfunk.gradle.plugin.development.convention"
-version = "0.0.4"
+version = "0.0.5"
 
 repositories {
     gradlePluginPortal()

--- a/plugin-development/gradle-plugin-convention/build.gradle.kts
+++ b/plugin-development/gradle-plugin-convention/build.gradle.kts
@@ -28,6 +28,7 @@ plugins {
     jacoco
     alias(libsPluginConvention.plugins.binaryCompatibilityValidator)
     alias(libsPluginConvention.plugins.gradleMavenPublishPlugin)
+    alias(libsPluginConvention.plugins.gradleVersionCatalogAccessor)
 }
 
 group = "eu.bitfunk.gradle.plugin.development.convention"
@@ -45,6 +46,15 @@ gradlePlugin {
         id = "eu.bitfunk.gradle.plugin.development.convention"
         implementationClass = "eu.bitfunk.gradle.plugin.development.convention.GradlePluginConventionPlugin"
     }
+}
+
+versionCatalogAccessor {
+    packageName.set("eu.bitfunk.gradle.plugin.development.convention.libs")
+    catalogNames.set(listOf("libs-plugin-convention"))
+}
+
+apiValidation {
+    ignoredPackages.add("eu.bitfunk.gradle.plugin.development.convention.libs.generated")
 }
 
 java {

--- a/plugin-development/gradle-plugin-convention/gradle.properties
+++ b/plugin-development/gradle-plugin-convention/gradle.properties
@@ -1,2 +1,2 @@
 # Included builds
-includeTestUtils=false
+includeTestUtils=true

--- a/plugin-development/gradle-plugin-convention/gradle/libs-plugin-convention.versions.toml
+++ b/plugin-development/gradle-plugin-convention/gradle/libs-plugin-convention.versions.toml
@@ -2,9 +2,12 @@
 kotlin = "1.6.21"
 gradle = "7.5.1"
 jUnit5 = "5.9.1"
+mockk = "1.13.2"
 gradleTestUtil = "0.1.0"
+jacoco = "0.8.8"
 kotlinBinaryCompatibility = "0.12.1"
 gradleMavenPublishPlugin = "0.22.0"
+gradleVersionCatalogAccessor = "0.0.1-SNAPSHOT"
 
 [libraries]
 gradleKotlinPlugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
@@ -13,9 +16,10 @@ gradleKotlinDsl = "org.gradle.kotlin:gradle-kotlin-dsl-plugins:2.3.3"
 gradleMavenPublishPlugin = { module = "com.vanniktech:gradle-maven-publish-plugin", version.ref = "gradleMavenPublishPlugin"}
 testJUnit5 = { module = "org.junit.jupiter:junit-jupiter", version.ref = "jUnit5" }
 testJUnit5Engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "jUnit5" }
-testMockk = "io.mockk:mockk:1.13.2"
+testMockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 testGradleTestUtil = { module = "eu.bitfunk.gradle.plugin.development.test:gradle-test-util", version.ref = "gradleTestUtil" }
 
 [plugins]
 binaryCompatibilityValidator = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version.ref = "kotlinBinaryCompatibility" }
 gradleMavenPublishPlugin = { id = "com.vanniktech.maven.publish.base", version.ref = "gradleMavenPublishPlugin"}
+gradleVersionCatalogAccessor = { id = "eu.bitfunk.gradle.plugin.development.version.catalog.accessor", version.ref = "gradleVersionCatalogAccessor" }

--- a/plugin-development/gradle-plugin-convention/src/main/kotlin/eu/bitfunk/gradle/plugin/development/convention/GradlePluginConventionPlugin.kt
+++ b/plugin-development/gradle-plugin-convention/src/main/kotlin/eu/bitfunk/gradle/plugin/development/convention/GradlePluginConventionPlugin.kt
@@ -20,6 +20,7 @@ package eu.bitfunk.gradle.plugin.development.convention
 
 import eu.bitfunk.gradle.plugin.development.convention.GradlePluginConventionContract.Extension
 import eu.bitfunk.gradle.plugin.development.convention.internal.PublishingConfig
+import eu.bitfunk.gradle.plugin.development.convention.libs.generated.LibsPluginConventionVersionCatalogAccessor
 import org.gradle.api.GradleException
 import org.gradle.api.JavaVersion
 import org.gradle.api.Plugin
@@ -103,12 +104,16 @@ public class GradlePluginConventionPlugin : Plugin<Project>, GradlePluginConvent
     }
 
     public override fun configureDependencies(project: Project): Unit = with(project) {
+        val libs = LibsPluginConventionVersionCatalogAccessor(project)
+
         dependencies {
             testImplementation(gradleTestKit())
-            testImplementation("org.junit.jupiter:junit-jupiter:$JUNIT_5_VERSION")
-            testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:$JUNIT_5_VERSION")
-            testImplementation("io.mockk:mockk:$MOCKK_VERSION")
-            testImplementation("eu.bitfunk.gradle.plugin.development.test:gradle-test-util:$GRADLE_TEST_UTIL")
+            testImplementation("org.junit.jupiter:junit-jupiter:${libs.versions.jUnit5.getStatic()}")
+            testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:${libs.versions.jUnit5.getStatic()}")
+            testImplementation("io.mockk:mockk:${libs.versions.mockk.getStatic()}")
+            testImplementation(
+                "eu.bitfunk.gradle.plugin.development.test:gradle-test-util:${libs.versions.gradleTestUtil.getStatic()}"
+            )
         }
     }
 
@@ -119,8 +124,10 @@ public class GradlePluginConventionPlugin : Plugin<Project>, GradlePluginConvent
     }
 
     public override fun configureTestCoverage(project: Project): Unit = with(project) {
+        val libs = LibsPluginConventionVersionCatalogAccessor(project)
+
         jacoco {
-            toolVersion = JACOCO_VERSION
+            toolVersion = libs.versions.jacoco.getStatic()
         }
     }
 
@@ -152,19 +159,15 @@ public class GradlePluginConventionPlugin : Plugin<Project>, GradlePluginConvent
     }
 
     public override fun configureGradleWrapper(project: Project): Unit = with(project) {
+        val libs = LibsPluginConventionVersionCatalogAccessor(project)
+
         tasks.named<Wrapper>("wrapper") {
-            gradleVersion = GRADLE_VERSION
+            gradleVersion = libs.versions.gradle.getStatic()
             distributionType = Wrapper.DistributionType.ALL
         }
     }
 
     private companion object {
-        const val GRADLE_VERSION = "7.5.1"
-        const val JUNIT_5_VERSION = "5.8.2"
-        const val MOCKK_VERSION = "1.12.8"
-        const val JACOCO_VERSION = "0.8.8"
-        const val GRADLE_TEST_UTIL = "0.1.0"
-
         const val COVERAGE_MINIMUM = 0.95
     }
 }

--- a/plugin-development/gradle-plugin-convention/src/main/kotlin/eu/bitfunk/gradle/plugin/development/convention/internal/PublishingConfig.kt
+++ b/plugin-development/gradle-plugin-convention/src/main/kotlin/eu/bitfunk/gradle/plugin/development/convention/internal/PublishingConfig.kt
@@ -29,7 +29,7 @@ import java.time.Year
 
 internal object PublishingConfig {
     @Suppress("UnstableApiUsage")
-    internal fun Project.mavenPublishing(action: Action<MavenPublishBaseExtension>) {
+    private fun Project.mavenPublishing(action: Action<MavenPublishBaseExtension>) {
         extensions.configure(MavenPublishBaseExtension::class.java, action)
     }
 
@@ -40,53 +40,52 @@ internal object PublishingConfig {
     ): Unit = with(project) {
         pluginManager.apply("com.vanniktech.maven.publish.base")
 
-        mavenPublishing {
-            publishToMavenCentral(SonatypeHost.S01)
-            signAllPublications()
-            configure(
-                GradlePlugin(
-                    javadocJar = Javadoc(),
-                    sourcesJar = true
-                )
-            )
-
-            pom {
-                val gitHubOrg = extension.publishGitHubOrganization.get()
-                val gitHubRepo = extension.publishGitHubRepositoryName.get()
-
-                name.set(extension.publishName)
-                description.set(extension.publishDescription)
-                inceptionYear.set("${Year.now().value}")
-                url.set(
-                    "https://github.com/$gitHubOrg/$gitHubRepo/"
+        afterEvaluate {
+            mavenPublishing {
+                publishToMavenCentral(SonatypeHost.S01)
+                signAllPublications()
+                configure(
+                    GradlePlugin(
+                        javadocJar = Javadoc(),
+                        sourcesJar = true
+                    )
                 )
 
-                licenses {
-                    license {
-                        name.set("ISC License")
-                        url.set("https://opensource.org/licenses/isc")
-                        distribution.set("https://opensource.org/licenses/isc")
-                    }
-                }
-
-                developers {
-                    developer {
-                        id.set("bitfunk")
-                        name.set("Wolf-Martell Montwé (bitfunk)")
-                        url.set("https://github.com/bitfunk/")
-                    }
-                }
-
-                scm {
+                pom {
+                    name.set(extension.publishName)
+                    description.set(extension.publishDescription)
+                    inceptionYear.set("${Year.now().value}")
                     url.set(
-                        "https://github.com/$gitHubOrg/$gitHubRepo/"
+                        "https://github.com/${extension.publishGitHubOrganization.get()}/${extension.publishGitHubRepositoryName.get()}/"
                     )
-                    connection.set(
-                        "scm:git:git://github.com/$gitHubOrg/$gitHubRepo.git"
-                    )
-                    developerConnection.set(
-                        "scm:git:ssh://github.com/$gitHubOrg/$gitHubRepo.git"
-                    )
+
+                    licenses {
+                        license {
+                            name.set("ISC License")
+                            url.set("https://opensource.org/licenses/isc")
+                            distribution.set("https://opensource.org/licenses/isc")
+                        }
+                    }
+
+                    developers {
+                        developer {
+                            id.set("bitfunk")
+                            name.set("Wolf-Martell Montwé (bitfunk)")
+                            url.set("https://github.com/bitfunk/")
+                        }
+                    }
+
+                    scm {
+                        url.set(
+                            "https://github.com/${extension.publishGitHubOrganization.get()}/${extension.publishGitHubRepositoryName.get()}/"
+                        )
+                        connection.set(
+                            "scm:git:git://github.com/${extension.publishGitHubOrganization.get()}/${extension.publishGitHubRepositoryName.get()}.git"
+                        )
+                        developerConnection.set(
+                            "scm:git:ssh://github.com/${extension.publishGitHubOrganization.get()}/${extension.publishGitHubRepositoryName.get()}.git"
+                        )
+                    }
                 }
             }
         }

--- a/plugin-development/gradle-plugin-convention/src/test/kotlin/eu/bitfunk/gradle/plugin/development/convention/GradlePluginConventionPluginTest.kt
+++ b/plugin-development/gradle-plugin-convention/src/test/kotlin/eu/bitfunk/gradle/plugin/development/convention/GradlePluginConventionPluginTest.kt
@@ -476,6 +476,9 @@ class GradlePluginConventionPluginTest {
         val extension: GradlePluginConventionPluginExtension = mockk(relaxed = true)
         every { project.pluginManager } returns mockk(relaxed = true)
         every { project.repositories } returns mockk(relaxed = true)
+        stubGradleAction(project) {
+            project.afterEvaluate(it)
+        }
         every { project.extensions } returns extensionContainer
         every { project.dependencies } returns mockk(relaxed = true)
         every { project.tasks } returns mockk(relaxed = true)

--- a/plugin-development/gradle-plugin-convention/src/test/kotlin/eu/bitfunk/gradle/plugin/development/convention/GradlePluginConventionPluginTest.kt
+++ b/plugin-development/gradle-plugin-convention/src/test/kotlin/eu/bitfunk/gradle/plugin/development/convention/GradlePluginConventionPluginTest.kt
@@ -243,9 +243,9 @@ class GradlePluginConventionPluginTest {
             dependencyHandlerScope.gradleTestKit()
 
             dependencyHandlerScope.add("testImplementation", gradleTestKitDependency)
-            dependencyHandlerScope.add("testImplementation", "org.junit.jupiter:junit-jupiter:5.8.2")
-            dependencyHandlerScope.add("testRuntimeOnly", "org.junit.jupiter:junit-jupiter-engine:5.8.2")
-            dependencyHandlerScope.add("testImplementation", "io.mockk:mockk:1.12.8")
+            dependencyHandlerScope.add("testImplementation", "org.junit.jupiter:junit-jupiter:5.9.1")
+            dependencyHandlerScope.add("testRuntimeOnly", "org.junit.jupiter:junit-jupiter-engine:5.9.1")
+            dependencyHandlerScope.add("testImplementation", "io.mockk:mockk:1.13.2")
             dependencyHandlerScope.add(
                 "testImplementation",
                 "eu.bitfunk.gradle.plugin.development.test:gradle-test-util:0.1.0"

--- a/plugin-development/gradle-plugin-convention/src/test/kotlin/eu/bitfunk/gradle/plugin/development/convention/internal/PublishingConfigTest.kt
+++ b/plugin-development/gradle-plugin-convention/src/test/kotlin/eu/bitfunk/gradle/plugin/development/convention/internal/PublishingConfigTest.kt
@@ -29,6 +29,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import io.mockk.verifyAll
+import org.gradle.api.Action
 import org.gradle.api.Project
 import org.gradle.api.plugins.ExtensionContainer
 import org.gradle.api.plugins.PluginManager
@@ -62,6 +63,9 @@ class PublishingConfigTest {
         extensionContainer = mockk()
         mavenPublishBaseExtension = mockk(relaxed = true)
 
+        stubGradleAction(project) {
+            project.afterEvaluate(it)
+        }
         every { project.pluginManager } returns pluginManager
         every { project.extensions } returns extensionContainer
         every { project.group } returns "group"
@@ -101,6 +105,7 @@ class PublishingConfigTest {
         verifyAll {
             project.pluginManager
             project.extensions
+            project.afterEvaluate(any<Action<Project>>())
 
             extensionContainer.configure(MavenPublishBaseExtension::class.java, any())
 

--- a/plugin-development/gradle.properties
+++ b/plugin-development/gradle.properties
@@ -1,2 +1,2 @@
 # Included builds
-includeConventionPlugin=false
+includeConventionPlugin=true

--- a/plugin-development/version-catalog-accessor/build.gradle.kts
+++ b/plugin-development/version-catalog-accessor/build.gradle.kts
@@ -22,7 +22,7 @@ plugins {
 }
 
 group = "eu.bitfunk.gradle.plugin.development"
-version = "0.0.1-SNAPSHOT"
+version = "0.1.0"
 
 gradlePlugin {
     plugins.create("gradlePluginVersionCatalog") {

--- a/plugin-development/version-catalog-accessor/gradle/libs-catalog-accessor.versions.toml
+++ b/plugin-development/version-catalog-accessor/gradle/libs-catalog-accessor.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-gradlePluginConvention = "0.0.3-SNAPSHOT"
+gradlePluginConvention = "0.0.5"
 
 [libraries]
 kotlinPoet = "com.squareup:kotlinpoet:1.12.0"

--- a/plugin-development/version-catalog-accessor/src/main/kotlin/eu/bitfunk/gradle/plugin/development/version/catalog/accessor/intern/VersionCatalogAccessorClassGenerator.kt
+++ b/plugin-development/version-catalog-accessor/src/main/kotlin/eu/bitfunk/gradle/plugin/development/version/catalog/accessor/intern/VersionCatalogAccessorClassGenerator.kt
@@ -203,7 +203,7 @@ internal class VersionCatalogAccessorClassGenerator(
     }
 
     private fun generateGetStaticFunction(catalogType: KClass<*>, value: String?): FunSpec {
-        val satement: String = when (catalogType) {
+        val statement: String = when (catalogType) {
             Versions::class -> "return \"$value\""
             Libraries::class -> THROW_UNSUPPORTED
             Bundles::class -> THROW_UNSUPPORTED
@@ -214,7 +214,7 @@ internal class VersionCatalogAccessorClassGenerator(
         return FunSpec.builder(FUNCTION_NAME_GET_STATIC)
             .addModifiers(OVERRIDE)
             .returns(String::class)
-            .addStatement(satement)
+            .addStatement(statement)
             .build()
     }
 


### PR DESCRIPTION
## 🚀 Description

Convention plugin is using version catalog accessor to remove hard coded versions

Release 
- version catalog accessor as 0.1.0
- convention as 0.0.5

## 📦 Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### ✅ Checklist

- [x] My code follows the code style and naming conventions of this project.
- [x] I have updated the documentation (if appropriate).
- [x] I have updated the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
