### PR TITLE
Fix Kotlin Gradle files falsely included from build folder

### DIFF
--- a/config/detekt/baseline.yml
+++ b/config/detekt/baseline.yml
@@ -3,6 +3,7 @@
   <ManuallySuppressedIssues></ManuallySuppressedIssues>
   <CurrentIssues>
     <ID>ComplexCondition:Dangerfile.df.kts$!isFeatureBranch &amp;&amp; !isReleaseBranch &amp;&amp; !isDependabotBranch &amp;&amp; !isRenovateBranch</ID>
+    <ID>LongMethod:FormatterPluginTest.kt$FormatterPluginTest$@Test fun `GIVEN project WHEN configureFormatter() THEN formatter configured`()</ID>
     <ID>LongMethod:PublishingConfigTest.kt$PublishingConfigTest$@Test fun `GIVEN project WHEN configurePublishing() THEN publishing pom configured`()</ID>
     <ID>MaxLineLength:PublishingConfig.kt$PublishingConfig$"https://github.com/${extension.publishGitHubOrganization.get()}/${extension.publishGitHubRepositoryName.get()}/"</ID>
     <ID>MaxLineLength:PublishingConfig.kt$PublishingConfig$"scm:git:git://github.com/${extension.publishGitHubOrganization.get()}/${extension.publishGitHubRepositoryName.get()}.git"</ID>

--- a/plugins/quality/formatter/CHANGELOG.md
+++ b/plugins/quality/formatter/CHANGELOG.md
@@ -11,6 +11,10 @@ This project adheres to [semantic versioning](http://semver.org/spec/v2.0.0.html
 
 See [changeset](https://github.com/bitfunk/gradle-plugins/compare/plugin-quality-formatter@v0.1.0...main)
 
+### Fixed
+
+- Fix Kotlin Gradle files falsely included from build folder
+
 ### Bumped
 
 - Spotless 6.11.0 -> 6.12.0

--- a/plugins/quality/formatter/src/main/kotlin/eu/bitfunk/gradle/plugin/quality/formatter/FormatterPlugin.kt
+++ b/plugins/quality/formatter/src/main/kotlin/eu/bitfunk/gradle/plugin/quality/formatter/FormatterPlugin.kt
@@ -54,6 +54,7 @@ public class FormatterPlugin : Plugin<Project>, FormatterContract.Plugin {
             }
             kotlinGradle {
                 target("**/*.gradle.kts", "**/*.df.kts")
+                targetExclude("**/build/")
                 trimTrailingWhitespace()
                 indentWithSpaces()
                 endWithNewline()

--- a/plugins/quality/formatter/src/test/kotlin/eu/bitfunk/gradle/plugin/quality/formatter/FormatterPluginTest.kt
+++ b/plugins/quality/formatter/src/test/kotlin/eu/bitfunk/gradle/plugin/quality/formatter/FormatterPluginTest.kt
@@ -138,6 +138,7 @@ class FormatterPluginTest {
             kotlinExtension.endWithNewline()
 
             kotlinGradleExtension.target("**/*.gradle.kts", "**/*.df.kts")
+            kotlinGradleExtension.targetExclude("**/build/")
             kotlinGradleExtension.trimTrailingWhitespace()
             kotlinGradleExtension.indentWithSpaces()
             kotlinGradleExtension.endWithNewline()


### PR DESCRIPTION
## 🚀 Description

Fix Kotlin Gradle files falsely included from build folder which results in false positive report.

## 📦 Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### ✅ Checklist

- [x] My code follows the code style and naming conventions of this project.
- [x] I have updated the documentation (if appropriate).
- [x] I have updated the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
