### PR TITLE
Fix Git version code

### DIFF
--- a/.github/workflows/ci-pull-request-validation-test-report.yml
+++ b/.github/workflows/ci-pull-request-validation-test-report.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - uses: dorny/test-reporter@v1
-        if: failure()
+        if: always()
         with:
           name: JUnit Tests
           path: '**/build/reports/tests/**/*.xml'

--- a/Dangerfile.df.kts
+++ b/Dangerfile.df.kts
@@ -48,7 +48,7 @@ danger(args) {
     val pullRequestBodyMinLines = 20
 
     val allSourceFiles = git.modifiedFiles + git.createdFiles
-    val isChangelogUpdated = allSourceFiles.contains("CHANGELOG.md")
+    val isChangelogUpdated = allSourceFiles.contains("CHANGELOG.md") || allSourceFiles.contains("**/CHANGELOG.md")
 
     onGitHub {
         val branchName = pullRequest.head.label.substringAfter(":")

--- a/config/detekt/baseline.yml
+++ b/config/detekt/baseline.yml
@@ -5,6 +5,7 @@
     <ID>ComplexCondition:Dangerfile.df.kts$!isFeatureBranch &amp;&amp; !isReleaseBranch &amp;&amp; !isDependabotBranch &amp;&amp; !isRenovateBranch</ID>
     <ID>LongMethod:FormatterPluginTest.kt$FormatterPluginTest$@Test fun `GIVEN project WHEN configureFormatter() THEN formatter configured`()</ID>
     <ID>LongMethod:PublishingConfigTest.kt$PublishingConfigTest$@Test fun `GIVEN project WHEN configurePublishing() THEN publishing pom configured`()</ID>
+    <ID>MaxLineLength:GitVersionLoader.kt$GitVersionLoader.Companion$"(v)?(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?".toRegex()</ID>
     <ID>MaxLineLength:PublishingConfig.kt$PublishingConfig$"https://github.com/${extension.publishGitHubOrganization.get()}/${extension.publishGitHubRepositoryName.get()}/"</ID>
     <ID>MaxLineLength:PublishingConfig.kt$PublishingConfig$"scm:git:git://github.com/${extension.publishGitHubOrganization.get()}/${extension.publishGitHubRepositoryName.get()}.git"</ID>
     <ID>MaxLineLength:PublishingConfig.kt$PublishingConfig$"scm:git:ssh://github.com/${extension.publishGitHubOrganization.get()}/${extension.publishGitHubRepositoryName.get()}.git"</ID>

--- a/docs/develop/RELEASING.md
+++ b/docs/develop/RELEASING.md
@@ -8,7 +8,7 @@ A tag needs to be in the form of `v{major}.{minor}.{patch}`.
 
 1. Create a release branch of from `main` branch with this pattern:
 
-- `release/{major}.{minor}/prepare-{major}.{minor}.{patch}`
+   - `release/{major}.{minor}/prepare-{major}.{minor}.{patch}`
 
 2. Update CHANGELOG.md by creating a new Unreleased section and change current unreleased to release version
 3. Update the latest release [badge](badges.md)

--- a/plugins/tool/git-version/CHANGELOG.md
+++ b/plugins/tool/git-version/CHANGELOG.md
@@ -15,6 +15,11 @@ See [changeset](https://github.com/bitfunk/gradle-plugins/compare/plugin-tool-gi
 
 - Fix issue that SemVer interprets some git hashes as semantic version
 
+### Bumped
+
+- SemVer 1.1.1 -> 1.2.0
+- jGit 6.3.0.202209071007-r -> 6.4.0.202211300538-r
+
 ## [0.1.0](https://github.com/bitfunk/gradle-plugins/releases/tag/plugin-tool-git-version@v0.1.0)
 
 Initial release Git Version Plugin - for easy project versioning using Git tags.

--- a/plugins/tool/git-version/CHANGELOG.md
+++ b/plugins/tool/git-version/CHANGELOG.md
@@ -11,6 +11,10 @@ This project adheres to [semantic versioning](http://semver.org/spec/v2.0.0.html
 
 See [changeset](https://github.com/bitfunk/gradle-plugins/compare/plugin-tool-git-version@v0.1.0...main)
 
+### Fixed
+
+- Fix issue that SemVer interprets some git hashes as semantic version
+
 ## [0.1.0](https://github.com/bitfunk/gradle-plugins/releases/tag/plugin-tool-git-version@v0.1.0)
 
 Initial release Git Version Plugin - for easy project versioning using Git tags.

--- a/plugins/tool/git-version/gradle/libs-git-version.versions.toml
+++ b/plugins/tool/git-version/gradle/libs-git-version.versions.toml
@@ -1,6 +1,6 @@
 [versions]
-jGit = "6.3.0.202209071007-r"
-semVer = "1.1.1"
+jGit = "6.4.0.202211300538-r"
+semVer = "1.2.0"
 plugin-gradlePluginConvention = "0.0.7"
 
 [libraries]

--- a/plugins/tool/git-version/src/main/kotlin/eu/bitfunk/gradle/plugin/tool/gitversion/GitVersionLoader.kt
+++ b/plugins/tool/git-version/src/main/kotlin/eu/bitfunk/gradle/plugin/tool/gitversion/GitVersionLoader.kt
@@ -73,7 +73,7 @@ public class GitVersionLoader(
     }
 
     private fun versionCode(description: String): Int {
-        return if (description.isEmpty()) {
+        return if (description.isEmpty() || !SEMANTIC_VERSION_REGEX.matches(description)) {
             -1
         } else {
             var versionDescription = description
@@ -135,6 +135,8 @@ public class GitVersionLoader(
     }
 
     private companion object {
+        private val SEMANTIC_VERSION_REGEX =
+            "(v)?(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?".toRegex()
         private val PREFIX_REGEX = "[/@]?([A-Za-z]+[/@-])+".toRegex()
         private val TAG_REGEX = "(.*)(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(.*)".toRegex()
         private val CLEAN_TAG_REGEX = ".*g.?[0-9a-fA-F]{3,}".toRegex()

--- a/plugins/tool/git-version/src/test/kotlin/eu/bitfunk/gradle/plugin/tool/gitversion/GitVersionLoaderCornerCaseTest.kt
+++ b/plugins/tool/git-version/src/test/kotlin/eu/bitfunk/gradle/plugin/tool/gitversion/GitVersionLoaderCornerCaseTest.kt
@@ -1,0 +1,82 @@
+/*
+ * ISC License
+ *
+ * Copyright (c) 2022. Wolf-Martell Montwé (bitfunk)
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+ * REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+ * INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+ * LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+ * OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+ * PERFORMANCE OF THIS SOFTWARE.
+ */
+
+package eu.bitfunk.gradle.plugin.tool.gitversion
+
+import io.mockk.every
+import io.mockk.mockk
+import org.eclipse.jgit.api.DescribeCommand
+import org.eclipse.jgit.api.Git
+import org.eclipse.jgit.api.Status
+import org.eclipse.jgit.lib.ObjectId
+import org.eclipse.jgit.lib.Ref
+import org.eclipse.jgit.lib.Repository
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+internal class GitVersionLoaderCornerCaseTest {
+
+    @Test
+    fun `GIVEN no tag and special commit number WHEN loadGitVersionInfo THEN version is hash`() {
+        // GIVEN
+        val gitHashFull = "7324508646fd6d8813e8f80a62d55efaabdd7aa5"
+        val gitHash = "7324508"
+        val git: Git = mockk()
+        val describe: DescribeCommand = mockk()
+        val repository: Repository = mockk()
+        val masterRef: Ref = mockk()
+        val headRef: Ref = mockk()
+        val headObjectId: ObjectId = mockk()
+        val status: Status = mockk()
+
+        every { git.describe() } returns describe
+        every { describe.setAlways(true) } returns describe
+        every { describe.call() } returns gitHash
+
+        every { git.repository } returns repository
+        every { repository.branch } returns "master"
+
+        every { repository.findRef("master") } returns masterRef
+        every { masterRef.name } returns "refs/heads/master"
+
+        every { repository.findRef("HEAD") } returns headRef
+        every { headRef.objectId } returns headObjectId
+        every { headObjectId.name } returns gitHashFull
+
+        every { git.status().call() } returns status
+        every { status.isClean } returns true
+
+        // WHEN
+        val result = GitVersionLoader(git, "").loadGitVersionInfo()
+
+        // THEN
+        assertEquals(
+            expected = GitVersionInfo(
+                version = "7324508",
+                versionCode = -1,
+                branchName = "master",
+                gitHashFull = "7324508646fd6d8813e8f80a62d55efaabdd7aa5",
+                gitHash = "7324508",
+                lastTag = "unspecified",
+                isCleanTag = true,
+                commitDistance = 0
+            ),
+            actual = result
+        )
+    }
+}


### PR DESCRIPTION
## 🚀 Description

The SemVer library treats Git hashes as valid semantic versions when the short hash only contains digits. This is wrong for this plugin. The version is now checked against [official regex](https://semver.org/spec/v2.0.0.html#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string)

### Bumped

- SemVer 1.1.1 -> 1.2.0
- jGit 6.3.0.202209071007-r -> 6.4.0.202211300538-r

## 📦 Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### ✅ Checklist

- [x] My code follows the code style and naming conventions of this project.
- [x] I have updated the documentation (if appropriate).
- [x] I have updated the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
